### PR TITLE
chore(ci): remove depot runner usage

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   conventional-commit:
     name: Conventional Commit
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Check PR Conventional Commit title
         uses: amannn/action-semantic-pull-request@v5


### PR DESCRIPTION
Remove depot runner from conventional commit job (added in an erroneous copy / paste job). 