### PR TITLE
deps: bump flagsmith-flag-engine to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ url = "2.1"
 chrono = { version = "0.4" }
 log = "0.4"
 flume = "0.10.14"
-flagsmith-flag-engine = "0.5.0"
+flagsmith-flag-engine = "0.5.1"
 
 [dev-dependencies]
 httpmock = "0.6"

--- a/src/flagsmith/mod.rs
+++ b/src/flagsmith/mod.rs
@@ -451,6 +451,7 @@ mod tests {
 
     static ENVIRONMENT_JSON: &str = r#"{
         "api_key": "B62qaMZNwfiqT76p38ggrQ",
+        "name": "Test Environment",
         "project": {
           "name": "Test project",
           "organisation": {

--- a/tests/fixtures/environment.json
+++ b/tests/fixtures/environment.json
@@ -1,5 +1,6 @@
 {
             "api_key": "B62qaMZNwfiqT76p38ggrQ",
+            "name": "Test Environment",
             "project": {
                 "name": "Test project",
                 "organisation": {


### PR DESCRIPTION
Update test fixtures to include required `name` field on Environment struct introduced in flag-engine 0.5.1.