### PR TITLE
ci: setup Renovate for flagsmith-flag-engine tracking

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended", ":semanticCommitScopeDisabled"],
+    "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
+    "semanticCommitType": "deps",
+    "packageRules": [
+        {
+            "matchUpdateTypes": [
+                "major",
+                "minor",
+                "patch",
+                "digest",
+                "pin",
+                "rollback",
+                "bump",
+                "replacement",
+                "lockFileMaintenance"
+            ],
+            "enabled": false
+        },
+        {
+            "matchPackageNames": ["flagsmith-flag-engine"],
+            "enabled": true
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Adds Renovate configuration to automatically track `flagsmith-flag-engine` crate updates and security vulnerabilities.

| Rule | Effect |
|---|---|
| `extends: config:recommended` | Renovate defaults (Dependency Dashboard, etc.) |
| Disable all routine updates | All `matchUpdateTypes` except `vulnerabilityAlerts` → blocked |
| Enable flagsmith-flag-engine | Tracks new releases on crates.io and opens PRs |
| **CVE / security alerts** | Pass through (not in disabled list) |

**Net effect**: only two things trigger PRs — a new `flagsmith-flag-engine` release, or a CVE on any dependency.