### PR TITLE
chore(deps): bump flagsmith-flag-engine to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ url = "2.1"
 chrono = { version = "0.4" }
 log = "0.4"
 flume = "0.10.14"
-flagsmith-flag-engine = "0.5.1"
+flagsmith-flag-engine = "0.6"
 
 [dev-dependencies]
 httpmock = "0.6"


### PR DESCRIPTION
## Summary

- Bump `flagsmith-flag-engine` from 0.5.1 to 0.6.0

## What changed in flag-engine 0.6

Additive only — no breaking changes:
- Added `feature_type: String` field to `FeatureMetadata` (with `serde(default)`)
- Made `Feature::feature_type` visibility `pub` (was private)
- Plumbed `feature_type` through engine eval mappers

None of the types this client uses (`FlagsmithValue`, `FlagsmithValueType`, `FeatureState`, `Environment`, `Trait`, `Segment`, `EvaluationResult`) were modified.

## Verification

All 40 tests pass locally (16 unit + 24 integration).

## Note

This unblocks [open-feature/rust-sdk-contrib#98](https://github.com/open-feature/rust-sdk-contrib/pull/98), which is currently failing due to a diamond dependency conflict (the `flagsmith` crate pinned flag-engine to 0.5 while the provider bumped to 0.6). Once this ships as a new `flagsmith` release, that PR can land.