### PR TITLE
feat!(deps): bump reqwest to 0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 #/target
 Cargo.lock
+.zed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["Flagsmith", "feature-flag", "remote-config"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.13", features = ["json", "blocking"], default-features = false }
 url = "2.1"
 chrono = { version = "0.4" }
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/Flagsmith/flagsmith-rust-client"
 readme = "README.md"
 categories = ["config", "api-bindings"]
 keywords = ["Flagsmith", "feature-flag", "remote-config"]
-rust-version = "1.85.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,14 @@ repository = "https://github.com/Flagsmith/flagsmith-rust-client"
 readme = "README.md"
 categories = ["config", "api-bindings"]
 keywords = ["Flagsmith", "feature-flag", "remote-config"]
+rust-version = "1.85.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.13", features = ["json", "blocking"], default-features = false }
+reqwest = { version = "0.13", features = ["json", "blocking"] }
 url = "2.1"
 chrono = { version = "0.4" }
 log = "0.4"


### PR DESCRIPTION
## Motivation
We are going to use the flagsmith rust client through its open feature provider in a complex rust project.

Because reqwest is still pinned to 0.11 it pulls a bunch of outdated deps but more importantly, the 0.11 default ssl backend is `openssl`. Because we make only fully static builds it breaks our build pipeline and we cant ship this.
The 0.13 version uses rustls which is entirely static.

## Side notes
* I added an MSRV to `Cargo.toml` which follows reqwest 0.13 MSRV.
* This is technically a breaking change, although minimal because of `impl From<reqwest::Error> for Error` which make the reqwest error type public.