### PR TITLE
feat!: declare MSRV 1.86 and enforce it in CI

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,22 @@
+name: MSRV
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  msrv:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install MSRV toolchain
+      run: rustup toolchain install 1.86.0 --profile minimal
+    - name: Check with MSRV
+      run: cargo +1.86.0 check --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/Flagsmith/flagsmith-rust-client"
 readme = "README.md"
 categories = ["config", "api-bindings"]
 keywords = ["Flagsmith", "feature-flag", "remote-config"]
+rust-version = "1.86.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to #49

Follow-up to the reqwest 0.13 bump, which raised the crate's effective MSRV: a fresh `cargo` resolve pulls `icu_*` 2.2.0 and `idna_adapter` 1.2.2 (via `url` -> `idna`), which require **rustc 1.86**. Building with 1.85.0 fails out of the box:

```
error: rustc 1.85.0 is not supported by the following packages:
  icu_collections@2.2.0 requires rustc 1.86
  idna_adapter@1.2.2 requires rustc 1.86
```

This PR:
- Declares `rust-version = "1.86.0"` in `Cargo.toml`
- Adds an `MSRV` workflow running `cargo +1.86.0 check`, so future dependency bumps cannot silently invalidate the advertised MSRV (the existing Rust workflow only builds on latest stable)

The `!` in the PR title is intentional: the breaking commit from #49 (`feat!(deps): ...`) could not be parsed by release-please (the `!` must come after the scope: `feat(deps)!:`), so no release PR was created — see the [workflow log](https://github.com/Flagsmith/flagsmith-rust-client/actions/runs/31394041369):

```
commit could not be parsed: 68ad120 feat!(deps): bump reqwest to 0.13 (#49)
error message: Error: unexpected token '(' at 1:6, valid tokens [(, :]
```

Squash-merging this PR with the title as-is lets release-please pick up the breaking change and cut **3.0.0**, covering both the reqwest 0.13 bump and the new MSRV.

## How did you test this code?

- `rustup toolchain install 1.86.0 --profile minimal` and `cargo +1.86.0 check` on this branch with a fresh resolve — passes (`Finished dev profile`)
- `cargo +1.85.0 check` on a clean checkout of main — fails with the `requires rustc 1.86` error above, confirming 1.86 is the true floor
- The new MSRV workflow runs on this PR itself, exercising the same check in CI