### PR TITLE
fix: improve http error details

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@ use std::convert::From;
 use std::error;
 use std::fmt;
 
+use reqwest::StatusCode;
+
 /// Wraps several types of errors.
 #[derive(Debug)]
 pub struct Error {
@@ -20,6 +22,13 @@ impl Error{
         Error{
             kind,
             msg
+        }
+    }
+
+    pub fn http(status: StatusCode, body: String) -> Error {
+        Error {
+            kind: ErrorKind::FlagsmithAPIError,
+            msg: format!("HTTP Api error: {status}, {body}")
         }
     }
 }

--- a/src/flagsmith/mod.rs
+++ b/src/flagsmith/mod.rs
@@ -434,13 +434,11 @@ fn get_json_response(
         request = request.body(body.unwrap());
     };
     let response = request.send()?;
-    if response.status().is_success() {
+    let status = response.status();
+    if status.is_success() {
         return Ok(response.json()?);
     } else {
-        return Err(error::Error::new(
-            error::ErrorKind::FlagsmithAPIError,
-            response.text()?,
-        ));
+        return Err(error::Error::http(status, response.text()?));
     }
 }
 


### PR DESCRIPTION
Follow up of https://github.com/Flagsmith/edge-proxy-rs/pull/15.

HTTP requests error logs were not complete enough to allow correct debugging.
Small improvement, adding the kind and the status.